### PR TITLE
Executable for OS X

### DIFF
--- a/init/org.znapzend.plist.in
+++ b/init/org.znapzend.plist.in
@@ -5,7 +5,7 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/usr/local/zfs/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+			<string>/usr/local/zfs/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 	</dict>
 	<key>KeepAlive</key>
 	<dict>


### PR DESCRIPTION
Executable for OS X is plain 'znapzend' (not 'org.znapzend'), and lives under '/opt/znapzend-0.21.0/bin/' (for the current version).